### PR TITLE
Entrypoint warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6.13.0
+      - image: cimg/node:10.24.1
 
     working_directory: ~/rentdynamics-js
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rentdynamics",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "rentdynamics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Package to help facilitate communicating with the Rent Dynamics API",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "scripts": {
     "build": "npm run tsc && npm run webpack",
     "nsp": "nsp check",


### PR DESCRIPTION
This fixes the following warning for node 16+ consumers:
```
[DEP0128] DeprecationWarning: Invalid ‘main’ field in 
‘{CONSUMER_PROJECT_PATH}/node_modules/rentdynamics/package.json’ of ‘dist/index.js’. 
Please either fix that or report it to the module author (Use `node --trace-deprecation ...` 
to show where the warning was created)
```

Looking at the `rentdynamics` directory under `node_modules` shows `dist/index.js` and `dist/index.d.ts` are invalid paths as the `package.json` is living side by side with those files. Node is resolving this issue for us by falling back to the default setting (just index.js). With Node 16 this has become a deprecation warning. This PR simply removes the invalid paths and continues to use the defaults.

Note the `types` entry wasn't giving me warnings, but I decided to change it as well since it seems to be the same issue.