### PR TITLE
Ensure all spaces are removed when formatting payloads

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -113,6 +113,8 @@ export class ClientHelpers {
 
         if (typeof payload === undefined || payload === null) {
             formattedPayload = null;
+        } else if (typeof (payload) === 'string') {
+            formattedPayload = payload.replace(/ /g, '');
         } else if (payload !== Object(payload)) {
             formattedPayload = payload;
         } else if (Array.isArray(payload)) {


### PR DESCRIPTION
## PR Checklist
 * Which ticket is this associated with?
    * Closes [CRM-2501](https://rentdynamics.atlassian.net/browse/CRM-2501)
 * Description
    * When calculating the nonce, we format the payload and are _supposed_ to remove all spaces from strings. I discovered a case where space characters are not removed from strings that reside within an array, resulting in a nonce error when we compare it to the nonce computed in Python.
    * This PR corrects that bug.


[CRM-2501]: https://rentdynamics.atlassian.net/browse/CRM-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ